### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/io.github.seadve.Breathing.metainfo.xml.in
+++ b/data/io.github.seadve.Breathing.metainfo.xml.in
@@ -32,7 +32,7 @@
   <content_rating type="oars-1.1"/>
   <releases>
     <release version="0.1.3" date="2024-03-24">
-      <description translatable="no">
+      <description translate="no">
         <p>This release contains the following changes:</p>
         <ul>
           <li>Dialogs are now adaptive</li>
@@ -41,7 +41,7 @@
       </description>
     </release>
     <release version="0.1.2" date="2022-04-08">
-      <description translatable="no">
+      <description translate="no">
         <p>This is a simple release with behind the scenes fixes.</p>
         <ul>
           <li>Port to libadwaita</li>
@@ -50,7 +50,7 @@
       </description>
     </release>
     <release version="0.1.1" date="2021-08-05">
-      <description translatable="no">
+      <description translate="no">
         <p>This is a simple release with behind the scenes fixes.</p>
         <ul>
           <li>Better support for smaller form factor</li>
@@ -72,7 +72,7 @@
       </description>
     </release>
     <release version="0.1.0" date="2021-05-14">
-      <description translatable="no">
+      <description translate="no">
         <p>Initial release.</p>
       </description>
     </release>
@@ -82,9 +82,9 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
-  <developer_name translatable="no">Dave Patrick Caberto</developer_name>
+  <developer_name translate="no">Dave Patrick Caberto</developer_name>
   <developer id="io.github.seadve">
-    <name translatable="no">Dave Patrick Caberto</name>
+    <name translate="no">Dave Patrick Caberto</name>
   </developer>
   <update_contact>davecruz48@gmail.com</update_contact>
   <launchable type="desktop-id">io.github.seadve.Breathing.desktop</launchable>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: `https://github.com/ximion/appstream/issues/623`

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html