### PR TITLE
desktop: add HealthFitness and Mindfulness categories

### DIFF
--- a/data/io.github.seadve.Breathing.desktop.in
+++ b/data/io.github.seadve.Breathing.desktop.in
@@ -4,7 +4,7 @@ Exec=breathing
 Icon=io.github.seadve.Breathing
 Terminal=false
 Type=Application
-Categories=GTK;GNOME;Utility;
+Categories=GTK;GNOME;HealthFitness;Mindfulness;Utility;
 StartupNotify=true
 # Translators: These are search terms to find this application. Do NOT translate or localize the semicolons. The list MUST also end with a semicolon.
 Keywords=Utility;Breath;Exercise;


### PR DESCRIPTION
HealthFitness and Mindfulness were recently added as FreeDesktop categories.

You can find HealthFitness as a main category: https://specifications.freedesktop.org/menu/latest/category-registry.html
You can find Mindfulness as an additional category: https://specifications.freedesktop.org/menu/latest/additional-category-registry.html